### PR TITLE
Update Pixiv2Billfish.py

### DIFF
--- a/Pixiv2Billfish.py
+++ b/Pixiv2Billfish.py
@@ -22,7 +22,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 from thread_pool import ThreadPool, callback
 
 # Billfish 数据库目录
-# eg.:"C:\pictures\.bf\billfish.db"
+# eg.:"C:/pictures/test/.bf/billfish.db"
 DB_PATH = r"billfish.db"
 
 # 选择使用代理链接


### PR DESCRIPTION
billfish.db 路径中含有“t”开头文件夹时，会提示找不到数据库，将DB_PATH示例中的“\”更改为“/”